### PR TITLE
Add an Examples page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "features": {
     "ghcr.io/devcontainers/features/hugo:1": {
       "extended": true,
-      "version": "0.132.2"
+      "version": "0.164.0"
     },
     "ghcr.io/devcontainers/features/node:1": {}
   },

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       DART_SASS_VERSION: 1.93.2
       GO_VERSION: 1.25.1
-      HUGO_VERSION: 0.151.0
+      HUGO_VERSION: 0.164.0
       NODE_VERSION: 22.18.0
       TZ: Europe/Oslo
     steps:

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ Event sourcing is useful for any application that wishes to capture not just the
 {{< cards >}}
   {{< card link="/docs/getting-started" title="Getting Started" icon="sun" >}}
   {{< card link="/docs" title="Documentation" icon="book-open" >}}
-  {{< card link="https://github.com/go-estoria/estoria-examples" title="Examples" icon="clipboard" >}}
+  {{< card link="/docs/examples" title="Examples" icon="clipboard" >}}
   {{< card link="/component-library" title="Component Library" icon="cog" >}}
   {{< card link="https://pkg.go.dev/github.com/go-estoria/estoria" title="GoDoc" icon="book-open" >}}
   {{< card link="https://github.com/go-estoria/estoria" title="GitHub" icon="github" >}}

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -10,4 +10,5 @@ type: docs
   {{< card link="/docs/components/aggregate-cache" title="Caching" icon="cog" >}}
   {{< card link="/docs/projections" title="Projections" icon="cog" >}}
   {{< card link="/docs/telemetry" title="Telemetry" icon="cog" >}}
+  {{< card link="/docs/examples" title="Examples" icon="clipboard" >}}
 {{< /cards >}}

--- a/content/docs/components/_index.md
+++ b/content/docs/components/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Components
 type: docs
-prev: docs/getting-started
+prev: docs/examples/
 next: docs/components/event_store
 sidebar:
   open: false

--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -6,27 +6,22 @@ next: docs/components/
 weight: 130
 ---
 
-Every example below lives in
-[estoria-examples](https://github.com/go-estoria/estoria-examples) as a
-self-contained Go module pinning released versions of `estoria` and
-`estoria-contrib`. Any one of them can be copied out of the repo on its own
-and run.
+Every example below lives in [estoria-examples](https://github.com/go-estoria/estoria-examples) as a self-contained Go module.
 
 ## Backend Quickstarts
 
-| Quickstart | What it covers |
+| Quickstart | What it Covers |
 | --- | --- |
 | [PostgreSQL](https://github.com/go-estoria/estoria-examples/tree/main/postgres) | Postgres event store, including the transactional outbox for reliable event delivery to external consumers. |
 | [MongoDB](https://github.com/go-estoria/estoria-examples/tree/main/mongodb) | MongoDB event store using a single-collection strategy. |
 | [KurrentDB](https://github.com/go-estoria/estoria-examples/tree/main/kurrent) | KurrentDB (formerly EventStoreDB) event store with native stream mapping. |
 | [OpenTelemetry](https://github.com/go-estoria/estoria-examples/tree/main/opentelemetry) | Instrumenting event, aggregate, and snapshot stores with OTEL tracing and metrics, against Jaeger, Prometheus, and Grafana. See [Telemetry](/docs/telemetry). |
 
-## Applications
+## Demo Applications
 
-Complete, runnable apps with web UIs, showing what event sourcing with Estoria
-looks like end to end.
+Runnable apps with web UIs, showcasing Estoria's event sourcing features and capabilities.
 
-| Example | What it demonstrates | Try it |
+| Example | What it Demonstrates | Try It |
 | --- | --- | --- |
 | [Kanban](https://github.com/go-estoria/estoria-examples/tree/main/kanban) | A real-time collaborative board with a time-travel slider, live sync over SSE, optimistic concurrency surfaced in the UI, and snapshotting. SQLite — no Docker required. | |
 | [Orders](https://github.com/go-estoria/estoria-examples/tree/main/orders) | An order-fulfillment service: a strict state-machine domain, the transactional outbox delivering events to a CQRS read model and webhook log, and a live admin dashboard. Postgres. | [orders.demo.estoria.dev](https://orders.demo.estoria.dev) |
@@ -34,12 +29,9 @@ looks like end to end.
 | [Chess](https://github.com/go-estoria/estoria-examples/tree/main/chess) | Two-player chess where each game is an event stream: move legality enforced inside `ApplyTo`, a replay slider, optimistic concurrency as turn-race protection, and PGN export. SQLite. | [chess.demo.estoria.dev](https://chess.demo.estoria.dev) |
 | [Inspector](https://github.com/go-estoria/estoria-examples/tree/main/inspector) | A read-only web tool for browsing any supported event store: stream lists, event paging, payload inspection, and a live global-feed tail. | |
 
-The hosted demos are seeded fresh at the top of every hour and accept writes
-from anyone — which is what makes the concurrency behavior worth watching.
-
 ### Concepts
 
-| If you want to see… | Read | In the code |
+| Concepts | Read | In the Code |
 | --- | --- | --- |
 | Entities, events, and `ApplyTo` | [Defining Entities](/docs/getting-started/defining-entities), [Defining Events](/docs/getting-started/defining-events) | `kanban/board.go`, `kanban/board_events.go` |
 | Optimistic concurrency and version conflicts | [Aggregate Store](/docs/components/aggregate-store) | `kanban/server.go` (`runCommand`), `chess/server.go` |

--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -1,8 +1,9 @@
 ---
 title: Examples
 type: docs
-prev: docs/typeids/
-weight: 840
+prev: docs/getting-started/
+next: docs/components/
+weight: 130
 ---
 
 Every example below lives in
@@ -11,40 +12,32 @@ self-contained Go module pinning released versions of `estoria` and
 `estoria-contrib`. Any one of them can be copied out of the repo on its own
 and run.
 
+## Backend Quickstarts
+
+| Quickstart | What it covers |
+| --- | --- |
+| [PostgreSQL](https://github.com/go-estoria/estoria-examples/tree/main/postgres) | Postgres event store, including the transactional outbox for reliable event delivery to external consumers. |
+| [MongoDB](https://github.com/go-estoria/estoria-examples/tree/main/mongodb) | MongoDB event store using a single-collection strategy. |
+| [KurrentDB](https://github.com/go-estoria/estoria-examples/tree/main/kurrent) | KurrentDB (formerly EventStoreDB) event store with native stream mapping. |
+| [OpenTelemetry](https://github.com/go-estoria/estoria-examples/tree/main/opentelemetry) | Instrumenting event, aggregate, and snapshot stores with OTEL tracing and metrics, against Jaeger, Prometheus, and Grafana. See [Telemetry](/docs/telemetry). |
+
 ## Applications
 
 Complete, runnable apps with web UIs, showing what event sourcing with Estoria
 looks like end to end.
 
-{{< cards >}}
-  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/kanban" title="Kanban" icon="view-boards" subtitle="A real-time collaborative board with a time-travel slider, live sync over SSE, optimistic concurrency surfaced in the UI, and snapshotting. SQLite — no Docker required." >}}
-  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/orders" title="Orders" icon="shopping-cart" subtitle="An order-fulfillment service: a strict state-machine domain, the transactional outbox delivering events to a CQRS read model and webhook log, and a live admin dashboard. Postgres." >}}
-  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/fleet" title="Fleet" icon="chip" subtitle="An IoT sensor-fleet dashboard with an in-process device simulator: long streams, the full snapshotting and caching decorator stack, and a live hydration benchmark. SQLite." >}}
-  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/chess" title="Chess" icon="puzzle" subtitle="Live two-player chess where each game is an event stream: move legality enforced inside ApplyTo, a replay slider, optimistic concurrency as turn-race protection, and PGN export. SQLite." >}}
-  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/inspector" title="Inspector" icon="search" subtitle="A read-only web tool for browsing any supported event store: stream lists, event paging, payload inspection, and a live global-feed tail." >}}
-{{< /cards >}}
+| Example | What it demonstrates | Try it |
+| --- | --- | --- |
+| [Kanban](https://github.com/go-estoria/estoria-examples/tree/main/kanban) | A real-time collaborative board with a time-travel slider, live sync over SSE, optimistic concurrency surfaced in the UI, and snapshotting. SQLite — no Docker required. | |
+| [Orders](https://github.com/go-estoria/estoria-examples/tree/main/orders) | An order-fulfillment service: a strict state-machine domain, the transactional outbox delivering events to a CQRS read model and webhook log, and a live admin dashboard. Postgres. | [orders.demo.estoria.dev](https://orders.demo.estoria.dev) |
+| [Fleet](https://github.com/go-estoria/estoria-examples/tree/main/fleet) | An IoT sensor-fleet dashboard with an in-process device simulator: long streams, the full snapshotting and caching decorator stack, and a live hydration benchmark. SQLite. | |
+| [Chess](https://github.com/go-estoria/estoria-examples/tree/main/chess) | Two-player chess where each game is an event stream: move legality enforced inside `ApplyTo`, a replay slider, optimistic concurrency as turn-race protection, and PGN export. SQLite. | [chess.demo.estoria.dev](https://chess.demo.estoria.dev) |
+| [Inspector](https://github.com/go-estoria/estoria-examples/tree/main/inspector) | A read-only web tool for browsing any supported event store: stream lists, event paging, payload inspection, and a live global-feed tail. | |
 
-### Try them without installing anything
+The hosted demos are seeded fresh at the top of every hour and accept writes
+from anyone — which is what makes the concurrency behavior worth watching.
 
-Two are running live. Both are seeded fresh at the top of every hour, so
-anything you do to them is temporary by design — and both accept writes from
-anyone, which is exactly what makes optimistic concurrency worth watching.
-
-- **[chess.demo.estoria.dev](https://chess.demo.estoria.dev)** — start a game,
-  then open it in a second tab and play both sides. Every move is an event
-  appended to that game's stream; the replay slider re-derives the position
-  from any prefix of it.
-- **[orders.demo.estoria.dev](https://orders.demo.estoria.dev)** — place an
-  order and watch the outbox monitor. The order list doesn't move when the
-  command succeeds; it moves a moment later, when the outbox processor
-  delivers the event and the read model catches up. That gap is the CQRS split,
-  made visible.
-
-These are a convenience, not part of the project's infrastructure. Every
-example runs locally with one command, and the deployment recipe
-(`Dockerfile` and `railway.toml`) lives beside each one in the repository.
-
-### Where to look for a given concept
+### Concepts
 
 | If you want to see… | Read | In the code |
 | --- | --- | --- |
@@ -58,16 +51,3 @@ example runs locally with one command, and the deployment recipe
 | CQRS with a read model | [CQRS](/docs/cqrs) | `orders/readmodel.go` |
 | The transactional outbox | [CQRS](/docs/cqrs) | `orders/main.go`, `orders/readmodel.go` |
 | Reading an event store directly | [Event Store](/docs/components/event-store) | `inspector/backend.go` |
-
-## Backend quickstarts
-
-The same short walkthrough of Estoria's core components, each wired to a
-different storage backend. Every one ships a `docker-compose.yml` and a
-Makefile for its dependencies.
-
-| Quickstart | What it covers |
-| --- | --- |
-| [PostgreSQL](https://github.com/go-estoria/estoria-examples/tree/main/postgres) | Postgres event store, including the transactional outbox for reliable event delivery to external consumers. |
-| [MongoDB](https://github.com/go-estoria/estoria-examples/tree/main/mongodb) | MongoDB event store using a single-collection strategy. |
-| [KurrentDB](https://github.com/go-estoria/estoria-examples/tree/main/kurrent) | KurrentDB (formerly EventStoreDB) event store with native stream mapping. |
-| [OpenTelemetry](https://github.com/go-estoria/estoria-examples/tree/main/opentelemetry) | Instrumenting event, aggregate, and snapshot stores with OTEL tracing and metrics, against Jaeger, Prometheus, and Grafana. See [Telemetry](/docs/telemetry). |

--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -1,0 +1,53 @@
+---
+title: Examples
+type: docs
+prev: docs/typeids/
+weight: 840
+---
+
+Every example below lives in
+[estoria-examples](https://github.com/go-estoria/estoria-examples) as a
+self-contained Go module that pins released versions of `estoria` and
+`estoria-contrib` — no `replace` directives. Any one of them can be copied out
+of the repo on its own and run.
+
+## Applications
+
+Complete, runnable apps with web UIs, showing what event sourcing with Estoria
+looks like end to end.
+
+{{< cards >}}
+  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/kanban" title="Kanban" icon="view-boards" subtitle="A real-time collaborative board with a time-travel slider, live sync over SSE, optimistic concurrency surfaced in the UI, and snapshotting. SQLite — no Docker required." >}}
+  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/orders" title="Orders" icon="shopping-cart" subtitle="An order-fulfillment service: a strict state-machine domain, the transactional outbox delivering events to a CQRS read model and webhook log, and a live admin dashboard. Postgres." >}}
+  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/fleet" title="Fleet" icon="chip" subtitle="An IoT sensor-fleet dashboard with an in-process device simulator: long streams, the full snapshotting and caching decorator stack, and a live hydration benchmark. SQLite." >}}
+  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/chess" title="Chess" icon="puzzle" subtitle="Live two-player chess where each game is an event stream: move legality enforced inside ApplyTo, a replay slider, optimistic concurrency as turn-race protection, and PGN export. SQLite." >}}
+  {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/inspector" title="Inspector" icon="search" subtitle="A read-only web tool for browsing any supported event store: stream lists, event paging, payload inspection, and a live global-feed tail." >}}
+{{< /cards >}}
+
+### Where to look for a given concept
+
+| If you want to see… | Read | In the code |
+| --- | --- | --- |
+| Entities, events, and `ApplyTo` | [Defining Entities](/docs/getting-started/defining-entities), [Defining Events](/docs/getting-started/defining-events) | `kanban/board.go`, `kanban/board_events.go` |
+| Optimistic concurrency and version conflicts | [Aggregate Store](/docs/components/aggregate-store) | `kanban/server.go` (`runCommand`), `chess/server.go` |
+| Loading an aggregate at a past version | [Event-Sourced Aggregate Store](/docs/components/aggregate-store/event-sourced) | `kanban/server.go`, `chess/server.go` |
+| Snapshotting on a policy | [Snapshotting Aggregate Store](/docs/components/aggregate-store/snapshotting), [Snapshot Store](/docs/components/snapshot-store) | `kanban/main.go`, `fleet/main.go` |
+| Hooks reacting to a save | [Hookable Aggregate Store](/docs/components/aggregate-store/hookable) | `kanban/main.go` (SSE broadcast on `AfterSave`) |
+| Aggregate caching, and what it's worth | [Cached Aggregate Store](/docs/components/aggregate-store/cached), [Aggregate Cache](/docs/components/aggregate-cache) | `fleet/main.go`, plus the hydration benchmark in `fleet/server.go` |
+| Projections over a stream | [Projections](/docs/projections) | `kanban/server.go` (activity feed) |
+| CQRS with a read model | [CQRS](/docs/cqrs) | `orders/readmodel.go` |
+| The transactional outbox | [CQRS](/docs/cqrs) | `orders/main.go`, `orders/readmodel.go` |
+| Reading an event store directly | [Event Store](/docs/components/event-store) | `inspector/backend.go` |
+
+## Backend quickstarts
+
+The same short walkthrough of Estoria's core components, each wired to a
+different storage backend. Every one ships a `docker-compose.yml` and a
+Makefile for its dependencies.
+
+| Quickstart | What it covers |
+| --- | --- |
+| [PostgreSQL](https://github.com/go-estoria/estoria-examples/tree/main/postgres) | Postgres event store, including the transactional outbox for reliable event delivery to external consumers. |
+| [MongoDB](https://github.com/go-estoria/estoria-examples/tree/main/mongodb) | MongoDB event store using a single-collection strategy. |
+| [KurrentDB](https://github.com/go-estoria/estoria-examples/tree/main/kurrent) | KurrentDB (formerly EventStoreDB) event store with native stream mapping. |
+| [OpenTelemetry](https://github.com/go-estoria/estoria-examples/tree/main/opentelemetry) | Instrumenting event, aggregate, and snapshot stores with OTEL tracing and metrics, against Jaeger, Prometheus, and Grafana. See [Telemetry](/docs/telemetry). |

--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -33,13 +33,13 @@ Runnable apps with web UIs, showcasing Estoria's event sourcing features and cap
 
 | Concepts | Read | In the Code |
 | --- | --- | --- |
-| Entities, events, and `ApplyTo` | [Defining Entities](/docs/getting-started/defining-entities), [Defining Events](/docs/getting-started/defining-events) | `kanban/board.go`, `kanban/board_events.go` |
-| Optimistic concurrency and version conflicts | [Aggregate Store](/docs/components/aggregate-store) | `kanban/server.go` (`runCommand`), `chess/server.go` |
-| Loading an aggregate at a past version | [Event-Sourced Aggregate Store](/docs/components/aggregate-store/event-sourced) | `kanban/server.go`, `chess/server.go` |
-| Snapshotting on a policy | [Snapshotting Aggregate Store](/docs/components/aggregate-store/snapshotting), [Snapshot Store](/docs/components/snapshot-store) | `kanban/main.go`, `fleet/main.go` |
-| Hooks reacting to a save | [Hookable Aggregate Store](/docs/components/aggregate-store/hookable) | `kanban/main.go` (SSE broadcast on `AfterSave`) |
-| Aggregate caching, and what it's worth | [Cached Aggregate Store](/docs/components/aggregate-store/cached), [Aggregate Cache](/docs/components/aggregate-cache) | `fleet/main.go`, plus the hydration benchmark in `fleet/server.go` |
-| Projections over a stream | [Projections](/docs/projections) | `kanban/server.go` (activity feed) |
-| CQRS with a read model | [CQRS](/docs/cqrs) | `orders/readmodel.go` |
-| The transactional outbox | [CQRS](/docs/cqrs) | `orders/main.go`, `orders/readmodel.go` |
-| Reading an event store directly | [Event Store](/docs/components/event-store) | `inspector/backend.go` |
+| Entities, events, and `ApplyTo` | [Defining Entities](/docs/getting-started/defining-entities), [Defining Events](/docs/getting-started/defining-events) | [`kanban/board.go`](https://github.com/go-estoria/estoria-examples/blob/main/kanban/board.go), [`kanban/board_events.go`](https://github.com/go-estoria/estoria-examples/blob/main/kanban/board_events.go) |
+| Optimistic concurrency and version conflicts | [Aggregate Store](/docs/components/aggregate-store) | [`kanban/server.go`](https://github.com/go-estoria/estoria-examples/blob/main/kanban/server.go) (`runCommand`), [`chess/server.go`](https://github.com/go-estoria/estoria-examples/blob/main/chess/server.go) |
+| Loading an aggregate at a past version | [Event-Sourced Aggregate Store](/docs/components/aggregate-store/event-sourced) | [`kanban/server.go`](https://github.com/go-estoria/estoria-examples/blob/main/kanban/server.go), [`chess/server.go`](https://github.com/go-estoria/estoria-examples/blob/main/chess/server.go) |
+| Snapshotting on a policy | [Snapshotting Aggregate Store](/docs/components/aggregate-store/snapshotting), [Snapshot Store](/docs/components/snapshot-store) | [`kanban/main.go`](https://github.com/go-estoria/estoria-examples/blob/main/kanban/main.go), [`fleet/main.go`](https://github.com/go-estoria/estoria-examples/blob/main/fleet/main.go) |
+| Hooks reacting to a save | [Hookable Aggregate Store](/docs/components/aggregate-store/hookable) | [`kanban/main.go`](https://github.com/go-estoria/estoria-examples/blob/main/kanban/main.go) (SSE broadcast on `AfterSave`) |
+| Aggregate caching, and what it's worth | [Cached Aggregate Store](/docs/components/aggregate-store/cached), [Aggregate Cache](/docs/components/aggregate-cache) | [`fleet/main.go`](https://github.com/go-estoria/estoria-examples/blob/main/fleet/main.go), plus the hydration benchmark in [`fleet/server.go`](https://github.com/go-estoria/estoria-examples/blob/main/fleet/server.go) |
+| Projections over a stream | [Projections](/docs/projections) | [`kanban/server.go`](https://github.com/go-estoria/estoria-examples/blob/main/kanban/server.go) (activity feed) |
+| CQRS with a read model | [CQRS](/docs/cqrs) | [`orders/readmodel.go`](https://github.com/go-estoria/estoria-examples/blob/main/orders/readmodel.go) |
+| The transactional outbox | [CQRS](/docs/cqrs) | [`orders/main.go`](https://github.com/go-estoria/estoria-examples/blob/main/orders/main.go), [`orders/readmodel.go`](https://github.com/go-estoria/estoria-examples/blob/main/orders/readmodel.go) |
+| Reading an event store directly | [Event Store](/docs/components/event-store) | [`inspector/backend.go`](https://github.com/go-estoria/estoria-examples/blob/main/inspector/backend.go) |

--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -7,9 +7,9 @@ weight: 840
 
 Every example below lives in
 [estoria-examples](https://github.com/go-estoria/estoria-examples) as a
-self-contained Go module that pins released versions of `estoria` and
-`estoria-contrib` — no `replace` directives. Any one of them can be copied out
-of the repo on its own and run.
+self-contained Go module pinning released versions of `estoria` and
+`estoria-contrib`. Any one of them can be copied out of the repo on its own
+and run.
 
 ## Applications
 

--- a/content/docs/examples.md
+++ b/content/docs/examples.md
@@ -24,6 +24,26 @@ looks like end to end.
   {{< card link="https://github.com/go-estoria/estoria-examples/tree/main/inspector" title="Inspector" icon="search" subtitle="A read-only web tool for browsing any supported event store: stream lists, event paging, payload inspection, and a live global-feed tail." >}}
 {{< /cards >}}
 
+### Try them without installing anything
+
+Two are running live. Both are seeded fresh at the top of every hour, so
+anything you do to them is temporary by design — and both accept writes from
+anyone, which is exactly what makes optimistic concurrency worth watching.
+
+- **[chess.demo.estoria.dev](https://chess.demo.estoria.dev)** — start a game,
+  then open it in a second tab and play both sides. Every move is an event
+  appended to that game's stream; the replay slider re-derives the position
+  from any prefix of it.
+- **[orders.demo.estoria.dev](https://orders.demo.estoria.dev)** — place an
+  order and watch the outbox monitor. The order list doesn't move when the
+  command succeeds; it moves a moment later, when the outbox processor
+  delivers the event and the read model catches up. That gap is the CQRS split,
+  made visible.
+
+These are a convenience, not part of the project's infrastructure. Every
+example runs locally with one command, and the deployment recipe
+(`Dockerfile` and `railway.toml`) lives beside each one in the repository.
+
 ### Where to look for a given concept
 
 | If you want to see… | Read | In the code |

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -16,7 +16,7 @@ go get github.com/go-estoria/estoria
 
 ## Quickstart
 
-Run all of the code below in a [Go playground](https://goplay.tools/snippet/sB6aDoAoNS_f). See other full runnable examples in [estoria-examples](https://github.com/go-estoria/estoria-examples).
+Run all of the code below in a [Go playground](https://goplay.tools/snippet/sB6aDoAoNS_f). For complete applications built on Estoria — a collaborative kanban board, an order-fulfillment service, a sensor fleet, chess — see [Examples](/docs/examples).
 
 ### Entities
 

--- a/content/docs/typeids.md
+++ b/content/docs/typeids.md
@@ -2,6 +2,7 @@
 title: TypeIDs
 type: docs
 prev: docs/cqrs/
+next: docs/examples/
 weight: 830
 ---
 

--- a/content/docs/typeids.md
+++ b/content/docs/typeids.md
@@ -2,7 +2,6 @@
 title: TypeIDs
 type: docs
 prev: docs/cqrs/
-next: docs/examples/
 weight: 830
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/imfing/hextra-starter-template
 
 go 1.21
 
-require github.com/imfing/hextra v0.8.2 // indirect
+require github.com/imfing/hextra v0.12.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.8.2 h1:/IykSIAywgKfhKUBgAW+dCCjrJWJNny4jr9qvdXfch0=
-github.com/imfing/hextra v0.8.2/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.12.3 h1:DZHY2rUWYteyzjlHi9r4n7Bb5e2Q+6LXe4C1Dqn0ZjM=
+github.com/imfing/hextra v0.12.3/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -25,7 +25,7 @@ menu:
       pageRef: /component-library
       weight: 2
     - name: Examples
-      url: "https://github.com/go-estoria/estoria-examples"
+      pageRef: /docs/examples
       weight: 3
     # - name: Contact ↗
     #   url: "https://github.com/imfing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@ publish = "public"
 command = "hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
 
 [build.environment]
-HUGO_VERSION = "0.132.2"
+HUGO_VERSION = "0.164.0"


### PR DESCRIPTION
## Summary

estoria-examples now has five complete applications and four backend quickstarts, so this adds a real Examples page (`/docs/examples`) and points those three links at it.

## Also in this PR: hextra v0.8.2 → v0.12.3

## Verification

Built locally with Hugo 0.164.0.
