### PR TITLE
Update documentation for estoria v0.7.0

### DIFF
--- a/content/docs/components/aggregate-store/_index.md
+++ b/content/docs/components/aggregate-store/_index.md
@@ -8,10 +8,10 @@ weight: 210
 
 An **aggregate** is a group of domain objects that is treated as a single unit. The aggregate's _root_ entity is the entrypoint through which we interact with and manage the state and behavior of all related objects.
 
-An **aggregate store** loads, hydrates, and saves aggregates. It is a generic component that requires an entity type as a type parameter:
+An **aggregate store** loads, hydrates, and saves aggregates. It is a generic component parameterized by the entity type it manages:
 
 ```go
-type AggregateStore[E estoria.Entity] interface {...}
+type Store[S any] interface {...}
 ```
 
 This enables it to instantiate new entities and events that are applicable to that entity type. To work with multiple entity types, simply create an aggregate store for each one.
@@ -36,21 +36,18 @@ The [cached aggregate store](./cached) wraps an underlying aggregate store and p
 
 The [hookable aggregate store](./hookable) wraps an underlying aggregate store and provides the ability to inject lifecycle hooks that are called before and after aggregates are loaded and saved.
 
-### Custom Aggregate Stores
+### Wrapping Aggregate Stores
 
-Anything implementing the following interface can be used as an aggregate store with Estoria:
+The `aggregatestore.Store[S]` interface is what the wrapping stores above compose over:
 
 ```go
-import (
-  "github.com/go-estoria/estoria/aggregatestore"
-  "github.com/go-estoria/estoria/entity"
-  "github.com/go-estoria/estoria/typeid"
-)
-
-type AggregateStore[E estoria.Entity] interface {
-    New(id uuid.UUID) (*aggregatestore.Aggregate[E], error)
-    Load(context.Context, typeid.ID, aggregatestore.LoadOptions) (*Aggregate[E], error)
-    Hydrate(context.Context, *aggregatestore.Aggregate[E], aggregatestore.HydrateOptions) error
-    Save(context.Context, *aggregatestore.Aggregate[E], aggregatestore.SaveOptions) error
+type Store[S any] interface {
+    AggregateType() string
+    New(id uuid.UUID) *Aggregate[S]
+    Load(ctx context.Context, id uuid.UUID, opts *LoadOptions) (*Aggregate[S], error)
+    Hydrate(ctx context.Context, aggregate *Aggregate[S], opts *HydrateOptions) error
+    Save(ctx context.Context, aggregate *Aggregate[S], opts *SaveOptions) error
 }
 ```
+
+Aggregate construction belongs exclusively to the `aggregatestore` package, so from-scratch third-party implementations of this interface are not supported. To extend aggregate store behavior, wrap an existing store — the snapshotting, cached, and hookable stores above are all examples of this pattern, delegating to an inner store and adding behavior around it. The pluggable surfaces are the event store, the snapshot store, and the aggregate cache.

--- a/content/docs/components/aggregate-store/cached.md
+++ b/content/docs/components/aggregate-store/cached.md
@@ -15,16 +15,19 @@ A cached aggregate store requires an inner aggregate store (to defer to when hyd
 ```go
 import (
     "context"
+
+    "github.com/allegro/bigcache/v3"
     "github.com/go-estoria/estoria/aggregatestore"
     "github.com/go-estoria/estoria-contrib/bigcache/aggregatecache"
 )
 
 func main() {
     // create an aggregate store
-    store, _ := aggregatestore.New(eventStore, NewThing)
+    store, _ := aggregatestore.New(eventStore, "thing", NewThing)
 
-    // create an aggregate cache
-    cache := aggregatecache.New()
+    // create an aggregate cache over a cache backend
+    backend, _ := bigcache.New(context.Background(), bigcache.DefaultConfig(time.Minute))
+    cache := aggregatecache.New[Thing](backend)
 
     // wrap an aggregate store with caching capabilities
     cachedStore, _ := aggregatestore.NewCachedStore(store, cache)
@@ -40,8 +43,10 @@ While the cached aggregate store is a core Estoria component, it relies on an ag
 Anything implementing the following interface can be used as an aggregate cache with Estoria:
 
 ```go
-type AggregateCache[E estoria.Entity] interface {
-	GetAggregate(ctx context.Context, aggregateID uuid.UUID) (*aggregatestore.Aggregate[E], error)
-	PutAggregate(ctx context.Context, aggregate *aggregatestore.Aggregate[E]) error
+type AggregateCache[S any] interface {
+	GetAggregate(ctx context.Context, aggregateID typeid.ID) (*aggregatestore.CachedAggregate[S], error)
+	PutAggregate(ctx context.Context, aggregateID typeid.ID, entry aggregatestore.CachedAggregate[S]) error
 }
 ```
+
+A cache stores and returns `CachedAggregate[S]` entries — a `{State, Version}` value — rather than aggregates. The cached store composes the aggregate itself from a hit, so a cache never needs to construct one. Returning `nil, nil` from `GetAggregate` signals a cache miss.

--- a/content/docs/components/aggregate-store/event-sourced.md
+++ b/content/docs/components/aggregate-store/event-sourced.md
@@ -17,7 +17,7 @@ import (
     "context"
     "github.com/go-estoria/estoria/aggregatestore"
     "github.com/go-estoria/estoria/eventstore/memory"
-    "github.com/google/uuid"
+    "github.com/gofrs/uuid/v5"
 )
 
 func main() {
@@ -25,7 +25,7 @@ func main() {
     eventStore, _ := memory.NewEventStore()
 
     // create the aggregate store
-    store, _ := aggregatestore.New(eventStore, NewThing,
+    store, _ := aggregatestore.New(eventStore, "thing", NewThing,
         aggregatestore.WithEventTypes(
             &NameChangedEvent{},
         ),
@@ -34,10 +34,10 @@ func main() {
     id := uuid.Must(uuid.NewV4())
 
     // create an aggregate
-    aggregate, _ := store.New(id)
+    aggregate := store.New(id)
 
     // append some events
-    _ = aggregate.Append(&NameChangedEvent{NewName: "Juliette"})
+    aggregate.Append(&NameChangedEvent{NewName: "Juliette"})
 
     // save the aggregate
     _ = store.Save(context.Background(), aggregate, nil)

--- a/content/docs/components/aggregate-store/hookable.md
+++ b/content/docs/components/aggregate-store/hookable.md
@@ -20,7 +20,7 @@ import (
 
 func main() {
     // create an aggregate store
-    store, _ := aggregatestore.New(eventStore, NewThing)
+    store, _ := aggregatestore.New(eventStore, "thing", NewThing)
 
     // wrap an aggregate store with hook capabilities
     hookableStore, _ := aggregatestore.NewHookableStore(store)

--- a/content/docs/components/aggregate-store/snapshotting.md
+++ b/content/docs/components/aggregate-store/snapshotting.md
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	// create an aggregate store
-	store, _ := aggregatestore.New(eventStore, NewThing)
+	store, _ := aggregatestore.New(eventStore, "thing", NewThing)
 
     // create a snapshot store
 	snapshotStore := memory.NewSnapshotStore()
@@ -47,7 +47,7 @@ The snapshotting aggregate store relies on the following components:
 - **An underlying aggregate store.** Because the snapshotting aggregate store can only hydrate aggregates to specific versions (those for which there are snapshots available), it must defer to another aggregate store to completely hydrate an aggregate to its latest version if events have been appended since the most recent snapshot.
 - **A snapshot store.** The snapshotting aggregate store needs to know how to save and load snapshots, and for this it uses a [snapshot store](../snapshot_store/).
 - **A snapshot policy.** The snapshot policy determines when a snapshot should be captured and saved. For example, a common policy is to capture a snapshot every N events.
-- **A snapshot marshaler.** By default, snapshots are marshaled as JSON, but this can be changed via an initialization option.
+- **A state codec.** By default, snapshot state is marshaled as JSON, but this can be changed via an initialization option.
 
 ### Snapshot Store
 
@@ -59,20 +59,23 @@ The snapshot policy determines when a snapshot should be captured and saved. The
 
 ## Options
 
-### Custom Snapshot Marshaler
+### Custom State Codec
 
-By default, the snapshotting aggregate store marshals snapshot data as JSON. You can override this behavior by providing an alternative snapshot marshaler using `WithSnapshotMarshaler()`.
+By default, the snapshotting aggregate store marshals snapshot state as JSON. You can override this behavior by providing an alternative state codec using `WithStateCodec()`. A state codec converts entity state to and from bytes:
 
 ```go
-import "github.com/go-estoria/estoria/aggregatestore"
+import (
+	"github.com/go-estoria/estoria"
+	"github.com/go-estoria/estoria/aggregatestore"
+)
 
-type CustomSnapshotMarshaler[E estoria.Entity] struct{}
+type CustomStateCodec[S any] struct{}
 
-func (m *CustomSnapshotMarshaler[E]) Marshal(src PT) ([]byte, error)
-func (m *CustomSnapshotMarshaler[E]) Unmarshal(data []byte, dest PT) error
+func (c CustomStateCodec[S]) MarshalState(state S) ([]byte, error)
+func (c CustomStateCodec[S]) UnmarshalState(data []byte, dest *S) error
 
-snapshottingStore, err := aggregatestore.NewSnapshottingReader(innerStore, snapshotter,
-	aggregatestore.WithSnapshotMarshaler(CustomSnapshotMarshaler{}))
+snapshottingStore, err := aggregatestore.NewSnapshottingStore(innerStore, snapshotStore, policy,
+	aggregatestore.WithStateCodec[Thing](CustomStateCodec[Thing]{}))
 ```
 
 ### Custom Snapshot Reader
@@ -88,8 +91,8 @@ func (CustomSnapshotReader) ReadSnapshot(ctx context.Context, aggregateID typeid
 	return nil, errors.New("todo: implement custom snapshot reader")
 }
 
-snapshottingStore, err := aggregatestore.NewSnapshottingReader(innerStore, snapshotter,
-	aggregatestore.WithSnapshotReader(CustomSnapshotReader{}))
+snapshottingStore, err := aggregatestore.NewSnapshottingStore(innerStore, snapshotStore, policy,
+	aggregatestore.WithSnapshotReader[Thing](CustomSnapshotReader{}))
 ```
 
 ### Custom Snapshot Writer
@@ -101,10 +104,10 @@ import "github.com/go-estoria/estoria/aggregatestore"
 
 type CustomSnapshotWriter struct{}
 
-func (CustomSnapshotWriter) ReadSnapshot(ctx context.Context, aggregateID typeid.ID) (*aggregatestore.Snapshot, error) {
-	return nil, errors.New("todo: implement custom snapshot writer")
+func (CustomSnapshotWriter) WriteSnapshot(ctx context.Context, snap *snapshotstore.AggregateSnapshot) error {
+	return errors.New("todo: implement custom snapshot writer")
 }
 
-snapshottingStore, err := aggregatestore.NewSnapshottingWriter(innerStore, snapshotter,
-	aggregatestore.WithSnapshotWriter(CustomSnapshotWriter{}))
+snapshottingStore, err := aggregatestore.NewSnapshottingStore(innerStore, snapshotStore, policy,
+	aggregatestore.WithSnapshotWriter[Thing](CustomSnapshotWriter{}))
 ```

--- a/content/docs/components/snapshot-store/event_stream.md
+++ b/content/docs/components/snapshot-store/event_stream.md
@@ -5,4 +5,26 @@ prev: docs/components/
 weight: 280
 ---
 
-An Aggregate Store loads and saves aggregates.
+The **event stream snapshot store** persists snapshots as events in the same event store that holds your aggregates' event streams — no separate snapshot storage is needed. Each aggregate's snapshots live in a parallel stream whose type name is the aggregate type with a `snapshot` suffix (a `user` aggregate's snapshots live in its `usersnapshot` stream).
+
+## Usage
+
+```go
+import "github.com/go-estoria/estoria/snapshotstore/eventstream"
+
+snapshotStore := eventstream.New(eventStore)
+```
+
+## Storage format
+
+A snapshot event's body is the snapshot's state payload, exactly as produced by the state codec. The aggregate version the snapshot captures rides in event metadata under `estoria.snapshot_version`, and a writer-supplied timestamp, when present, under `estoria.snapshot_timestamp`. Event metadata keys prefixed `estoria.` are reserved for Estoria itself; backends and callers must not write them.
+
+Because this store depends on metadata surviving the round trip through the backing event store, it requires an event store that faithfully persists event metadata — all estoria-contrib event stores do.
+
+## Retention
+
+Nothing deletes events, so this store retains every snapshot ever written. A bounded read (loading an aggregate at a specific version) walks the snapshot stream backwards to find the newest snapshot at or below the requested version, which makes time-travel loads efficient — but be aware that snapshot streams grow without bound.
+
+## Upgrading from before v0.7.0
+
+Snapshot events written by versions before v0.7.0 marshaled the whole snapshot envelope into the event body and carry no version metadata. Such events are skipped, never decoded as state. After an upgrade, the first load of each aggregate replays its full event stream, and the next snapshot write self-heals.

--- a/content/docs/cqrs.md
+++ b/content/docs/cqrs.md
@@ -39,7 +39,7 @@ func (a *Application) HandleModifyBalance(r *http.Request, w *http.ResponseWrite
 
     account, _ := a.accounts.Load(ctx, cmd.AccountID)
 
-    _ = account.Append(&ModifyBalanceEvent{
+    account.Append(&ModifyBalanceEvent{
         Amount: cmd.Amount,
     })
 

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -16,7 +16,7 @@ go get github.com/go-estoria/estoria
 
 ## Quickstart
 
-Run all of the code below in a [Go playground](https://goplay.tools/snippet/sB6aDoAoNS_f). For complete applications built on Estoria — a collaborative kanban board, an order-fulfillment service, a sensor fleet, chess — see [Examples](/docs/examples).
+Run all of the code below in a [Go playground](https://goplay.tools/snippet/0fWPXzLg8hp). For complete applications built on Estoria — a collaborative kanban board, an order-fulfillment service, a sensor fleet, chess — see [Examples](/docs/examples).
 
 ### Entities
 

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -6,7 +6,7 @@ next: docs/getting-started/defining-entities
 weight: 120
 ---
 
-Estoria requires Go >=1.25.
+Estoria requires Go >=1.26.
 
 ```shell
 go get github.com/go-estoria/estoria
@@ -20,7 +20,7 @@ Run all of the code below in a [Go playground](https://goplay.tools/snippet/sB6a
 
 ### Entities
 
-Entities must implement [`estoria.Entity`](https://pkg.go.dev/github.com/go-estoria/estoria#Entity) and provide a factory function:
+An entity is any type; no interface is required. Provide a factory function that builds one from a UUID:
 
 ```go
 type User struct {
@@ -28,17 +28,14 @@ type User struct {
 	Name string
 }
 
-func (a User) EntityID() typeid.ID { return typeid.New("user", a.ID) }
-
 func NewUser(id uuid.UUID) User {
 	return User{ID: id, Name: "Unknown"}
 }
-
 ```
 
 ### Events
 
-Events must implement [`estoria.EntityEvent`](https://pkg.go.dev/github.com/go-estoria/estoria#EntityEvent):
+Events must implement [`estoria.DomainEvent`](https://pkg.go.dev/github.com/go-estoria/estoria#DomainEvent):
 
 ```go
 type UserNameChanged struct {
@@ -47,13 +44,13 @@ type UserNameChanged struct {
 
 func (UserNameChanged) EventType() string { return "namechanged" }
 
-func (UserNameChanged) New() estoria.EntityEvent[User] {
+func (UserNameChanged) New() estoria.DomainEvent[User] {
 	return &UserNameChanged{NewName: "Unknown User"}
 }
 
-func (e UserNameChanged) ApplyTo(_ context.Context, user User) (User, error) {
+func (e UserNameChanged) ApplyTo(user User) User {
 	user.Name = e.NewName
-	return user, nil
+	return user
 }
 ```
 
@@ -65,10 +62,10 @@ Create an event store to store events:
 eventStore, _ := memory.NewEventStore()
 ```
 
-Then, create an aggregate store using the event store, your entity factory function, and your event types:
+Then, create an aggregate store using the event store, an aggregate type name, your entity factory function, and your event types. The type name becomes part of every aggregate's stream address, so it must remain stable for the lifetime of your data:
 
 ```go
-aggregateStore, _ := aggregatestore.New(eventStore, NewUser,
+aggregateStore, _ := aggregatestore.New(eventStore, "user", NewUser,
     aggregatestore.WithEventTypes(
         UserNameChanged{},
     ),
@@ -81,10 +78,10 @@ Now you can begin working with aggregates in your application:
 userID := uuid.Must(uuid.NewV4())
 
 // create a new User aggregate
-newUser := aggregateStore.New(userID, 0)
+newUser := aggregateStore.New(userID)
 
 // append an event
-_ = newUser.Append(UserNameChanged{NewName: "Juliette"})
+newUser.Append(UserNameChanged{NewName: "Juliette"})
 
 // save the aggregate
 _ = aggregateStore.Save(ctx, newUser, nil)
@@ -92,6 +89,6 @@ _ = aggregateStore.Save(ctx, newUser, nil)
 // load the aggregate
 loadedUser, _ := aggregateStore.Load(ctx, userID, nil)
 
-// access the aggregate root
-user := loadedUser.Entity()
+// access the aggregate's state
+user := loadedUser.State()
 ```

--- a/content/docs/getting-started/creating-an-aggregate-store.md
+++ b/content/docs/getting-started/creating-an-aggregate-store.md
@@ -13,13 +13,17 @@ Let's create a new aggregate store for Users in our application:
 ```go
 import "github.com/go-estoria/estoria/aggregatestore"
 
-aggregateStore, _ := aggregatestore.New(eventStore, NewUser,
+aggregateStore, _ := aggregatestore.New(eventStore, "user", NewUser,
     aggregatestore.WithEventTypes(
-        UserNameChangedEvent{},
+        UserNameChanged{},
     ),
 )
 ```
 
-Notice that we're passing in the event store and the factory function for our User type. This enables the aggregate store to instantiate a User before applying events to it in order to reconstruct its state. We're also telling the aggregate store what types of events can be used with our entity type.
+We're passing in four things: the event store, an **aggregate type name**, the factory function for our User type, and the event types that apply to Users.
+
+The aggregate type name (`"user"`) becomes the type component of every aggregate ID this store composes, which is how event streams are addressed in storage. Choose it once and keep it stable for the lifetime of your data — changing it later would strand existing streams under the old name. It must be non-empty and must not contain an underscore.
+
+The factory function enables the aggregate store to instantiate a User before applying events to it in order to reconstruct its state, and the registered event types tell the store which events it may encounter in a User's stream.
 
 Now that we have an aggregate store for Users, we can begin working with User aggregates.

--- a/content/docs/getting-started/defining-entities.md
+++ b/content/docs/getting-started/defining-entities.md
@@ -6,26 +6,20 @@ next: getting-started/defining-events
 weight: 121
 ---
 
-An **entity** is a uniquely-identifyable domain object that we want to store as an event-sourced record.
+An **entity** is a uniquely-identifyable domain object that we want to store as an event-sourced record. In Estoria, an entity is any Go type — no interface is required. The aggregate that manages an entity carries the identity and version; the entity itself only carries state.
 
-Let's create a User entity type for our application. Each user will have a unique identifier, a name, and a timestamp for when the user was last updated.
+Let's create a User entity type for our application:
 
 ```go
 type User struct {
-	ID        uuid.UUID
-	Name      string
+	ID   uuid.UUID
+	Name string
 }
 ```
 
-Our User type must implement the `estoria.Entity` interface, which requires defining an `EntityID()` method. This method should return a the User's _TypeID_, which is the User's UUID with an associated type name.
+The `ID` field here is optional — Estoria addresses aggregates by an ID it composes for you, so your entity may record its UUID, but it doesn't have to.
 
-```go
-func (a User) EntityID() typeid.ID {
-	return typeid.New("user", a.ID)
-}
-```
-
-Finally, we must define a **factory function** for creating Users. Name it whatever you like, and it should take a UUID and return a User object. Here, we're simply assigning the ID to the User and setting a default name.
+We must define a **factory function** for creating Users. Name it whatever you like; it should take a UUID and return a User object. The aggregate store uses it to build a fresh User before replaying events onto it. Here, we're assigning the ID to the User and setting a default name:
 
 ```go
 func NewUser(id uuid.UUID) User {

--- a/content/docs/getting-started/defining-events.md
+++ b/content/docs/getting-started/defining-events.md
@@ -6,7 +6,7 @@ next: getting-started/creating-an-event-store
 weight: 122
 ---
 
-An **event** represents a change to an entity, often with associated information. For example, an User changed their name. Events always represent something that has happened in the past. Let's define an event that represent this change to a User:
+An **event** represents a change to an entity, often with associated information. For example, a User changed their name. Events always represent something that has happened in the past. Let's define an event that represents this change to a User:
 
 ```go
 type UserNameChanged struct {
@@ -14,7 +14,7 @@ type UserNameChanged struct {
 }
 ```
 
-Our event must implement the `estoria.EntityEvent[User]` interface:
+Our event must implement the `estoria.DomainEvent[User]` interface:
 
 `EventType()` returns a string representation of the event type's name. This is used to identify the event type when storing and retrieving events:
 
@@ -27,22 +27,22 @@ func (UserNameChanged) EventType() string { return "namechanged" }
 ```go
 import "github.com/go-estoria/estoria"
 
-func (UserNameChanged) New() estoria.EntityEvent[User] {
+func (UserNameChanged) New() estoria.DomainEvent[User] {
 	return &UserNameChanged{NewName: "Unknown User"}
 }
 ```
 
 Note that the `New()` method does not utilize its receiver, as it is a factory function that creates a new instance of the event. This enables Estoria to create new instances of the event when reading from the event store. It also gives us the ability to set default values for the event's fields.
 
-`ApplyTo()` defines the logic for how the event mutates the entity. In this case, it sets the User's Name field based on the event's data.
+`ApplyTo()` defines the logic for how the event produces the entity's next state. In this case, it sets the User's Name field based on the event's data:
 
 ```go
-func (e UserNameChanged) ApplyTo(_ context.Context, user User) (User, error) {
-	log.Printf("applying user name changed event: %s", e.NewName)
+func (e UserNameChanged) ApplyTo(user User) User {
 	user.Name = e.NewName
-	user.UpdatedAt = time.Now()
-	return user, nil
+	return user
 }
 ```
+
+`ApplyTo` cannot fail: by the time an event is applied, it has already been persisted, and a persisted event is a fact. Validate commands *before* appending events to an aggregate — anything that could make the change invalid belongs in your command-handling code, not in `ApplyTo`. A payload that can't be decoded surfaces as an error during loading, before `ApplyTo` is ever reached.
 
 Now that we've defined an entity and some events, we're ready to create an event store for persisting events.

--- a/content/docs/getting-started/working-with-aggregates.md
+++ b/content/docs/getting-started/working-with-aggregates.md
@@ -15,13 +15,13 @@ Create a new aggregate with `New()`:
 ```go
 userID := uuid.Must(uuid.NewV4())
 
-newUser := aggregateStore.New(userID, 0)
+newUser := aggregateStore.New(userID)
 ```
 
-We'll also append an event to change the User's name to "Juliette"
+We'll also append an event to change the User's name to "Juliette". Appending only queues the event on the aggregate; nothing is persisted or applied until the aggregate is saved:
 
 ```go
-_ = newUser.Append(UserNameChanged{NewName: "Juliette"})
+newUser.Append(UserNameChanged{NewName: "Juliette"})
 ```
 
 ## Saving Aggregates
@@ -32,6 +32,8 @@ To save an aggregate, use `Save()`:
 _ = aggregateStore.Save(ctx, newUser, nil)
 ```
 
+Saving appends the queued events to the aggregate's event stream, then applies them to the in-memory state. If a save fails *after* its events were durably appended, the error carries the `aggregatestore.ErrEventsAppended` sentinel (check with `errors.Is`); recover by discarding the aggregate and reloading it.
+
 ## Loading Aggregates
 
 To load an aggregate, use `Load()`:
@@ -40,11 +42,10 @@ To load an aggregate, use `Load()`:
 loadedUser, _ := aggregateStore.Load(ctx, userID, nil)
 ```
 
-The aggregate's root entity can be accessed using `.Entity()`:
-
+The aggregate's state can be accessed using `.State()`:
 
 ```go
-user := loadedUser.Entity()
+user := loadedUser.State()
 ```
 
 We can also see what version the aggregate is at (i.e. how many events have been applied to it):

--- a/content/docs/projections.md
+++ b/content/docs/projections.md
@@ -71,11 +71,14 @@ _, err = proj.Project(ctx, projection.EventHandlerFunc(func(_ context.Context, e
     }
 
     var e BalanceChangedEvent
-    event, _ := json.Unmarshal(evt.Data, &e)
+    if err := json.Unmarshal(evt.Data, &e); err != nil {
+        return err
+    }
+
     _, err := db.Exec(
         "UPDATE accounts SET balance = balance + ? WHERE account_id = ?",
-        e.Amount, 
-        evt.ID.EntityID,
+        e.Amount,
+        evt.StreamID.UUID,
     )
     return err
 }))

--- a/content/docs/typeids.md
+++ b/content/docs/typeids.md
@@ -19,7 +19,6 @@ id := typeid.New("user", uuid.Must(uuid.FromString("978e35ad-876f-43df-8e7d-cbcb
 fmt.Println(id.Type)   // "user"
 fmt.Println(id.UUID)   // 978e35ad-876f-43df-8e7d-cbcb6dd855f9
 fmt.Println(id.String()) // "user_978e35ad-876f-43df-8e7d-cbcb6dd855f9"
-fmt.Println(id.ShortString()) // "user_550e8400"
 ```
 
 >Note that the Estoria `typeid` package is _not_ an implementation of [Jetify's TypeID specification](https://github.com/jetify-com/typeid/tree/main/spec). It is simply a struct that holds a type name and a UUID.


### PR DESCRIPTION
Updates every page touched by the v0.7.0 aggregate model rework ([release notes](https://github.com/go-estoria/estoria/releases/tag/v0.7.0)), and fixes several pre-existing example errors found along the way.

## v0.7.0 changes

- **Getting-started sequence**: entities are plain types — no `estoria.Entity` interface, no `EntityID()`; events implement `DomainEvent[S]` with a total `ApplyTo(S) S` (with a new explanation of why validation belongs before `Append`); the aggregate store constructor takes an explicit aggregate type name, documented with its keep-it-stable-forever consequence; aggregates come from `store.New(id)`; state is accessed with `.State()`; `Append` returns nothing. Go requirement is now ≥1.26.
- **Aggregate store index**: both interface listings replaced with the real `Store[S any]` including `AggregateType()`; the custom-implementations section is now a wrapping-stores section, since aggregate construction belongs exclusively to core and wrapping is the supported extension pattern.
- **Cached store**: documents the reshaped `AggregateCache` contract — `CachedAggregate[S]` entries keyed by `typeid.ID`, `nil, nil` as miss, caches never build aggregates.
- **Snapshotting store**: `WithSnapshotMarshaler` → `WithStateCodec` with the real codec shape.
- **Event-stream snapshot store**: the page was a placeholder with a copy-pasted description; it now documents the payload-plus-metadata format, the reserved `estoria.` metadata namespace, the metadata-fidelity requirement, unbounded retention, and pre-v0.7.0 upgrade behavior.
- **TypeIDs**: `ShortString()` no longer exists; example removed.

## Pre-existing fixes

- Snapshotting page referenced constructors that never existed (`NewSnapshottingReader`/`NewSnapshottingWriter`) and gave the custom snapshot *writer* a `ReadSnapshot` method.
- Projections example called `json.Unmarshal` with two return values and read a nonexistent `evt.ID.EntityID` field (now `evt.StreamID.UUID`).
- Cached-store example called `aggregatecache.New()` with no backend; it now shows a real bigcache construction.
- Event-sourced page imported `google/uuid` while using the gofrs API, and expected an error from `store.New`.

Known gap, deliberately left: the quickstart's Go playground link still points at a snippet with v0.6-era code — the snippet needs re-creating externally, then the link swap can follow.