### PR TITLE
Update documentation for estoria v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,11 @@
-# Hextra Starter Template
+# go-estoria.github.io
 
-[![Deploy Hugo site to Pages](https://github.com/imfing/hextra-starter-template/actions/workflows/pages.yaml/badge.svg)](https://github.com/imfing/hextra-starter-template/actions/workflows/pages.yaml)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/6e83fd88-5ffe-4808-9689-c0f3b100bfe3/deploy-status)](https://app.netlify.com/sites/hextra-starter-template/deploys)
-![Vercel Deployment Status](https://img.shields.io/github/deployments/imfing/hextra-starter-template/production?logo=vercel&logoColor=white&label=vercel&labelColor=black&link=https%3A%2F%2Fhextra-starter-template.vercel.app%2F)
+Source for [estoria.dev](https://estoria.dev), the documentation site for [Estoria](https://github.com/go-estoria/estoria), an event sourcing toolkit for Go.
 
-
-🐣 Minimal template for getting started with [Hextra](https://github.com/imfing/hextra)
-
-![hextra-template](https://github.com/imfing/hextra-starter-template/assets/5097752/c403b9a9-a76c-47a6-8466-513d772ef0b7)
-
-[🌐 Demo ↗](https://imfing.github.io/hextra-starter-template/)
-
-## Quick Start
-
-Use this template to create your own repository:
-
-<img src="https://docs.github.com/assets/cb-77734/mw-1440/images/help/repository/use-this-template-button.webp" width=400 />
-
-You can also quickly start developing using the following online development environment:
-
-- [GitHub Codespaces](https://github.com/codespaces) 
-    
-    [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/imfing/hextra-starter-template)
-
-    Create a new codespace and follow the [Local Development](#local-development) to launch the preview
-
-- [Gitpod](https://gitpod.io)
-
-    [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/imfing/hextra-starter-template)
-
-
-## Deployment
-
-### GitHub Pages
-
-A GitHub Actions workflow is provided in [`.github/workflows/pages.yaml`](./.github/workflows/pages.yaml) to [publish to GitHub Pages](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/) for free. 
-
-For details, see [Publishing with a custom GitHub Actions workflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow).
-
-Note: in the settings, make sure to set the Pages deployment source to **GitHub Actions**:
-
-<img src="https://github.com/imfing/hextra-starter-template/assets/5097752/99676430-884e-42ab-b901-f6534a0d6eee" width=600 />
-
-[Run the workflow manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) if it's not triggered automatically.
-
-### Netlify
-
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/imfing/hextra-starter-template)
-
-### Vercel
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fimfing%2Fhextra-starter-template&env=HUGO_VERSION)
-
-Override the configuration:
-
-<img src="https://github.com/imfing/hextra-starter-template/assets/5097752/e2e3cecd-c884-47ec-b064-14f896fee08d" width=600 />
+The site is built with [Hugo](https://gohugo.io) using the [Hextra](https://github.com/imfing/hextra) theme and deploys to GitHub Pages on merge to `main`.
 
 ## Local Development
 
-Pre-requisites: [Hugo](https://gohugo.io/getting-started/installing/), [Go](https://golang.org/doc/install) and [Git](https://git-scm.com)
-
 ```shell
-# Clone the repo
-git clone https://github.com/imfing/hextra-starter-template.git
-
-# Change directory
-cd hextra-starter-template
-
-# Start the server
-hugo mod tidy
-hugo server --logLevel debug --disableFastRender -p 1313
+hugo server
 ```
-
-### Update theme
-
-```shell
-hugo mod get -u
-hugo mod tidy
-```
-
-See [Update modules](https://gohugo.io/hugo-modules/use-modules/#update-modules) for more details.
-

--- a/content/docs/components/aggregate-store/snapshotting.md
+++ b/content/docs/components/aggregate-store/snapshotting.md
@@ -61,7 +61,7 @@ The snapshot policy determines when a snapshot should be captured and saved. The
 
 ### Custom State Codec
 
-By default, the snapshotting aggregate store marshals snapshot state as JSON. You can override this behavior by providing an alternative state codec using `WithStateCodec()`. A state codec converts entity state to and from bytes:
+By default, the snapshotting aggregate store marshals snapshot state as JSON. You can override this behavior by providing an alternative state codec using `WithStateCodec()`. A state codec converts entity state to and from bytes, and declares the MIME content type of the bytes it produces. The declaration is stored with each snapshot; a snapshot declaring a content type the store's codec does not read is skipped in favor of full event replay.
 
 ```go
 import (
@@ -73,6 +73,7 @@ type CustomStateCodec[S any] struct{}
 
 func (c CustomStateCodec[S]) MarshalState(state S) ([]byte, error)
 func (c CustomStateCodec[S]) UnmarshalState(data []byte, dest *S) error
+func (c CustomStateCodec[S]) ContentType() string
 
 snapshottingStore, err := aggregatestore.NewSnapshottingStore(innerStore, snapshotStore, policy,
 	aggregatestore.WithStateCodec[Thing](CustomStateCodec[Thing]{}))

--- a/content/docs/components/event-store.md
+++ b/content/docs/components/event-store.md
@@ -18,13 +18,18 @@ Estoria represents an event as:
 
 ```go
 type Event struct {
-	ID            typeid.ID
-	StreamID      typeid.ID
-	StreamVersion int64
-	Timestamp     time.Time
-	Data          []byte
+	ID              typeid.ID
+	StreamID        typeid.ID
+	StreamVersion   int64
+	GlobalPosition  *int64
+	Timestamp       time.Time
+	Data            []byte
+	DataContentType string
+	Metadata        map[string]string
 }
 ```
+
+`GlobalPosition` is the event's position in the store's global order, where the backend has one. `DataContentType` is the MIME type of `Data`, declared by the codec that produced the bytes and returned exactly as written. `Metadata` is optional key-value metadata persisted with the event; keys prefixed `estoria.` are reserved for Estoria itself.
 
 ## Event Stores
 
@@ -52,10 +57,12 @@ for {
 The `AppendStream` method appends one or more events to an event stream.
 
 ```go
-_ = eventStore.AppendStream(ctx, streamID, events []*eventstore.WritableEvent{
+written, _ := eventStore.AppendStream(ctx, streamID, []*eventstore.WritableEvent{
     {Type: "balancechanged", Data: []byte(`{"amount": 100}`)},
-}, eventstore.AppendStreamOptions{}) error
+}, eventstore.AppendStreamOptions{})
 ```
+
+On success, `AppendStream` returns the written events, populated exactly as a subsequent read of the stream would return them: the store-assigned IDs, stream versions, timestamps, and global positions.
 
 ### Event Store Implementations
 
@@ -72,9 +79,20 @@ import (
 )
 
 interface {
-    AppendStream(context.Context, typeid.ID, []*eventstore.WritableEvent, eventstore.AppendStreamOptions) error
+    AppendStream(context.Context, typeid.ID, []*eventstore.WritableEvent, eventstore.AppendStreamOptions) ([]*eventstore.Event, error)
     ReadStream(context.Context, typeid.ID, eventstore.ReadStreamOptions) (eventstore.StreamIterator, error)
 }
 ```
+
+The `eventstore/storetest` package provides an acceptance suite that verifies an implementation against the behaviors Estoria's components rely on.
+
+### Optional Capabilities
+
+Beyond reading and appending, an event store may implement optional interfaces. Callers discover support with a type assertion:
+
+- `eventstore.GlobalReader` reads events from all streams in the store's global order via `ReadAll`, resuming from an exclusive position — the substrate for [projections](../../projections) and read models.
+- `eventstore.StreamDeleter` deletes a stream outright via `DeleteStream`, or truncates it through a version when `ToVersion` is set.
+
+Each has a dedicated acceptance suite in `eventstore/storetest`.
 
 Reading and writing event streams are low-level operations in Estoria. Next, we'll see how to create an Aggregate Store that uses an event store to persist aggregates.

--- a/content/docs/components/snapshot-store/event_stream.md
+++ b/content/docs/components/snapshot-store/event_stream.md
@@ -12,7 +12,7 @@ The **event stream snapshot store** persists snapshots as events in the same eve
 ```go
 import "github.com/go-estoria/estoria/snapshotstore/eventstream"
 
-snapshotStore := eventstream.New(eventStore)
+snapshotStore, _ := eventstream.New(eventStore)
 ```
 
 ## Storage format
@@ -23,7 +23,15 @@ Because this store depends on metadata surviving the round trip through the back
 
 ## Retention
 
-Nothing deletes events, so this store retains every snapshot ever written. A bounded read (loading an aggregate at a specific version) walks the snapshot stream backwards to find the newest snapshot at or below the requested version, which makes time-travel loads efficient — but be aware that snapshot streams grow without bound.
+By default, this store retains every snapshot ever written. A bounded read (loading an aggregate at a specific version) walks the snapshot stream backwards to find the newest snapshot at or below the requested version, which makes time-travel loads efficient — but be aware that snapshot streams grow without bound.
+
+To bound them, use `WithMaxSnapshots`:
+
+```go
+snapshotStore, _ := eventstream.New(eventStore, eventstream.WithMaxSnapshots(3))
+```
+
+After each snapshot write, snapshots older than the newest `n` are pruned by truncating the snapshot stream. This requires a backing event store that implements `eventstore.StreamDeleter`, checked at construction. Pruning is best-effort: a prune failure is logged, never surfaced, and the next successful write prunes what the failed one missed.
 
 ## Upgrading from before v0.7.0
 

--- a/content/docs/getting-started/creating-an-aggregate-store.md
+++ b/content/docs/getting-started/creating-an-aggregate-store.md
@@ -22,7 +22,7 @@ aggregateStore, _ := aggregatestore.New(eventStore, "user", NewUser,
 
 We're passing in four things: the event store, an **aggregate type name**, the factory function for our User type, and the event types that apply to Users.
 
-The aggregate type name (`"user"`) becomes the type component of every aggregate ID this store composes, which is how event streams are addressed in storage. Choose it once and keep it stable for the lifetime of your data — changing it later would strand existing streams under the old name. It must be non-empty and must not contain an underscore.
+The aggregate type name (`"user"`) becomes the type component of every aggregate ID this store composes, which is how event streams are addressed in storage. Choose it once and keep it stable for the lifetime of your data — changing it later would strand existing streams under the old name. It must be non-empty and must not begin or end with an underscore; interior underscores are fine. The same grammar applies to event type names, validated when event types are registered.
 
 The factory function enables the aggregate store to instantiate a User before applying events to it in order to reconstruct its state, and the registered event types tell the store which events it may encounter in a User's stream.
 

--- a/content/docs/getting-started/creating-an-event-store.md
+++ b/content/docs/getting-started/creating-an-event-store.md
@@ -16,13 +16,14 @@ import "github.com/go-estoria/estoria/eventstore/memory"
 eventStore, _ := memory.NewEventStore()
 ```
 
-Using our event store, we can save and load events. The event store is agnostic to our entity types, so we can use it to store events for any entity type we define.
+Using our event store, we can save and load events. The event store is agnostic to our entity types — it stores opaque event payloads for any stream:
 
 ```go
-_ = eventStore.AppendEvents(context.Background(), typeid.NewV4("user"),
-    []eventstore.WriteableEvent{
-        &UserNameChanged{NewName: "Juliette"},
+_, _ = eventStore.AppendStream(context.Background(), typeid.NewV4("user"),
+    []*eventstore.WritableEvent{
+        {Type: "namechanged", Data: []byte(`{"NewName": "Juliette"}`)},
     },
+    eventstore.AppendStreamOptions{},
 )
 ```
 

--- a/content/docs/getting-started/working-with-aggregates.md
+++ b/content/docs/getting-started/working-with-aggregates.md
@@ -24,6 +24,24 @@ We'll also append an event to change the User's name to "Juliette". Appending on
 newUser.Append(UserNameChanged{NewName: "Juliette"})
 ```
 
+### Event Metadata
+
+Events can carry key-value metadata, persisted alongside the event data. Attach metadata to specific events with `AppendWithMetadata`:
+
+```go
+newUser.AppendWithMetadata(map[string]string{"request_id": requestID},
+    UserNameChanged{NewName: "Juliette"},
+)
+```
+
+To amend all of an aggregate's pending events at once — the natural fit for ambient context like correlation or trace IDs, typically injected from a `BeforeSave` hook — use `MergeEventMetadata`:
+
+```go
+newUser.MergeEventMetadata(map[string]string{"correlation_id": correlationID})
+```
+
+Metadata keys prefixed `estoria.` are reserved for Estoria itself; a save whose events carry one fails before anything is appended.
+
 ## Saving Aggregates
 
 To save an aggregate, use `Save()`:

--- a/content/docs/projections.md
+++ b/content/docs/projections.md
@@ -54,6 +54,23 @@ _, err = proj.Project(ctx, projection.EventHandlerFunc(func(_ context.Context, e
 }))
 ```
 
+## Projecting All Streams
+
+A projection over a single stream sees one aggregate's history. To build read models spanning every stream, use `ReadAll`, available from event stores that implement `eventstore.GlobalReader`:
+
+```go
+globalReader, ok := eventStore.(eventstore.GlobalReader)
+if !ok {
+    // this event store does not support global reads
+}
+
+iter, _ := globalReader.ReadAll(ctx, eventstore.ReadAllOptions{})
+
+proj, _ := projection.New(iter)
+```
+
+Events arrive in ascending global order, each carrying a `GlobalPosition`. Persist the last position your projection processed and resume from it with `ReadAllOptions{AfterPosition: position}` — the position is exclusive, so a resumed read continues with the first unprocessed event.
+
 ## Persistent Projections
 
 A projection that updates a persistent read model (e.g., a database table) is called a persistent projection. Persistent projections are typically used in CQRS systems to create read models that can be queried independently of the write model.

--- a/content/docs/typeids.md
+++ b/content/docs/typeids.md
@@ -21,4 +21,18 @@ fmt.Println(id.UUID)   // 978e35ad-876f-43df-8e7d-cbcb6dd855f9
 fmt.Println(id.String()) // "user_978e35ad-876f-43df-8e7d-cbcb6dd855f9"
 ```
 
+## Parsing
+
+`typeid.Parse` round-trips IDs from paths, query strings, and logs, accepting exactly what `ID.String` produces:
+
+```go
+id, err := typeid.Parse("user_978e35ad-876f-43df-8e7d-cbcb6dd855f9")
+```
+
+The UUID is always the final 36 characters of the string, so type names containing underscores parse unambiguously.
+
+## Type Names
+
+Type names must be non-empty and must not begin or end with an underscore. Interior underscores are fine, so snake_case names like `funds_deposited` work. The same grammar applies to aggregate type names and event type names, validated when an aggregate store is created and when event types are registered.
+
 >Note that the Estoria `typeid` package is _not_ an implementation of [Jetify's TypeID specification](https://github.com/jetify-com/typeid/tree/main/spec). It is simply a struct that holds a type name and a UUID.


### PR DESCRIPTION
Documents the estoria v0.8.0 capabilities across the site:

- **Working with Aggregates** gains an Event Metadata section: `AppendWithMetadata`, `MergeEventMetadata`, and the reserved `estoria.` key prefix.
- **Event Store** shows the full `Event` shape (`GlobalPosition`, `DataContentType`, `Metadata`), `AppendStream`'s returned written events, the updated custom-implementation interface, and a new Optional Capabilities section covering `GlobalReader` and `StreamDeleter` with type-assertion discovery and the `storetest` acceptance suites.
- **Projections** gains a Projecting All Streams section: `ReadAll` via `GlobalReader`, ascending global order, and checkpoint/resume with `AfterPosition`.
- **Event Stream snapshot store** documents the constructor's new error return and snapshot retention via `WithMaxSnapshots`, including its `StreamDeleter` requirement and best-effort pruning.
- **Snapshotting store**'s custom codec example gains the required `ContentType()` method and the content-type mismatch-skip behavior.
- **TypeIDs** gains Parsing (`typeid.Parse`) and Type Names sections with the relaxed grammar: non-empty, no leading or trailing underscore, interior underscores legal. The stale "must not contain an underscore" rule in Creating an Aggregate Store is replaced accordingly.

Also fixes the event-store quickstart example, which called a nonexistent `AppendEvents` method with domain events passed as writable events.

Also replaces the Hextra starter-template README with one describing this repo and linking to the site.
