### PR TITLE
Document per-backend capabilities and the transactional outbox

### DIFF
--- a/content/component-library.md
+++ b/content/component-library.md
@@ -13,11 +13,14 @@ These components are maintained by the Estoria project. They are tested against 
 
 ### Event Stores
 
-| Event Store | Driver | Details |
-|-------------|--------|---------|
-| **[KurrentDB](https://github.com/go-estoria/estoria-contrib/tree/main/kurrentdb/eventstore)** | https://github.com/kurrent-io/KurrentDB-Client-Go | Streams map closely to Kurrent streams. |
-| **[MongoDB](https://github.com/go-estoria/estoria-contrib/tree/main/mongodb/eventstore)** | https://github.com/mongodb/mongo-go-driver | Can choose between a single collection for all events or one collection per aggregate type. |
-| **[PostgreSQL](https://github.com/go-estoria/estoria-contrib/tree/main/postgres/eventstore)** | https://github.com/lib/pq | Uses a single table for all events. |
+| Event Store | Driver | Global Reads | Stream Deletion | Outbox | Details |
+|-------------|--------|--------------|-----------------|--------|---------|
+| **[KurrentDB](https://github.com/go-estoria/estoria-contrib/tree/main/kurrentdb/eventstore)** | [KurrentDB-Client-Go](https://github.com/kurrent-io/KurrentDB-Client-Go) | Yes | No | — | Streams map closely to Kurrent streams. |
+| **[MongoDB](https://github.com/go-estoria/estoria-contrib/tree/main/mongodb/eventstore)** | [mongo-go-driver](https://github.com/mongodb/mongo-go-driver) | Yes | Yes | [Yes](https://github.com/go-estoria/estoria-contrib/tree/main/mongodb/outbox) | A single collection for all events, or events partitioned across collections by a configurable selector. |
+| **[PostgreSQL](https://github.com/go-estoria/estoria-contrib/tree/main/postgres/eventstore)** | [pgx](https://github.com/jackc/pgx) | Yes | Yes | [Yes](https://github.com/go-estoria/estoria-contrib/tree/main/postgres/outbox) | Uses a single table for all events. |
+| **[SQLite](https://github.com/go-estoria/estoria-contrib/tree/main/sqlite/eventstore)** | [modernc.org/sqlite](https://gitlab.com/cznic/sqlite) | Yes | Yes | — | Uses a single table for all events; no CGO required. |
+
+**Global Reads** and **Stream Deletion** are the event store's [optional capabilities](/docs/components/event-store#optional-capabilities). KurrentDB's "No" for stream deletion is deliberate: its native delete semantics cannot honestly satisfy the interface's contract, so the store does not claim it (the rationale is in [its README](https://github.com/go-estoria/estoria-contrib/tree/main/kurrentdb/eventstore#unsupported-streamdeleter)). **Outbox** links to the store's companion [transactional outbox](/docs/cqrs#the-transactional-outbox) package, where one exists.
 
 ### Snapshot Stores
 

--- a/content/docs/components/event-store.md
+++ b/content/docs/components/event-store.md
@@ -95,4 +95,6 @@ Beyond reading and appending, an event store may implement optional interfaces. 
 
 Each has a dedicated acceptance suite in `eventstore/storetest`.
 
+Every officially supported implementation provides global reads, and all but KurrentDB support stream deletion — KurrentDB's native delete semantics cannot honestly satisfy the interface's contract, so that store deliberately does not claim it. The [Component Library](/component-library#event-stores) lists per-backend support.
+
 Reading and writing event streams are low-level operations in Estoria. Next, we'll see how to create an Aggregate Store that uses an event store to persist aggregates.

--- a/content/docs/cqrs.md
+++ b/content/docs/cqrs.md
@@ -98,3 +98,9 @@ This approach can become unwieldy as the number of events grows, or as querying 
 #### Dedicated Read Models
 
 If your aggregates are comprised of many events, or if you need more complex querying capabilities, you may want to build a dedicated read model. Rather than projecting an in-memory view when a query is made, you instead project events to a database whenever an aggregate changes. This database is often entirely separate from the database that backs the event store and is optimized for queries (reads) rather than writes.
+
+#### The Transactional Outbox
+
+A dedicated read model raises a delivery problem: the append to the event store and the update to the read model are writes to two different systems, and either can succeed while the other fails. The [transactional outbox](https://microservices.io/patterns/data/transactional-outbox.html) pattern closes that gap — each append also writes one outbox row per event *within the same database transaction*, so events and their pending deliveries commit or roll back together. A separate processor then works through the outbox, invoking your handler for each item and retrying on failure, giving at-least-once delivery to read models, webhooks, or message brokers. Handlers must be idempotent.
+
+The [PostgreSQL](https://github.com/go-estoria/estoria-contrib/tree/main/postgres/outbox) and [MongoDB](https://github.com/go-estoria/estoria-contrib/tree/main/mongodb/outbox) event stores each ship a companion outbox package. The [Orders example](/docs/examples) shows the pattern end to end: an outbox delivering events to a CQRS read model and a webhook log.


### PR DESCRIPTION
## Summary

Documents the per-backend optional-capability support that shipped in estoria-contrib v0.9.0/v0.10.0, and the transactional outbox.

- **Component Library:** the event store table gains **Global Reads**, **Stream Deletion**, and **Outbox** columns, the missing **SQLite** row, and current driver links (the PostgreSQL entry still pointed at `lib/pq`, which the pgx migration left behind; SQLite uses `modernc.org/sqlite`). A note under the table explains KurrentDB's deliberate stream-deletion "No" and links each store's outbox package where one exists.
- **Event Store page:** the Optional Capabilities section now says which official implementations support each capability — every backend provides global reads, all but KurrentDB support stream deletion — and points to the Component Library for the matrix.
- **CQRS page:** a new *The Transactional Outbox* section under Dedicated Read Models covers the dual-write problem, the in-transaction commit guarantee, and at-least-once delivery with idempotent handlers, linking the PostgreSQL and MongoDB outbox packages and the Orders example. The Examples page has linked "the transactional outbox" to the CQRS page since it was written, but the section did not exist until now.

Hugo build verified locally; all new internal links and anchors resolve in the rendered output.
