### PR TITLE
Add architecture, integrations, and troubleshooting pages

### DIFF
--- a/content/docs/architecture.md
+++ b/content/docs/architecture.md
@@ -1,0 +1,132 @@
+---
+title: Architecture Overview
+type: docs
+prev: docs/typeids/
+next: docs/integrations/
+weight: 840
+---
+
+This page is a high-level map of Estoria: how its components fit together, which one owns which responsibility, and where the extension points are.
+
+## Core Concepts
+
+Estoria maps event sourcing concepts onto a small set of Go types:
+
+- **Entity state** — a plain struct of your own (`Account`, `Order`, …) plus a factory function that produces its initial state. Estoria imposes no interface on it.
+- **`estoria.DomainEvent[S]`** — a state-changing event. `ApplyTo(state S) S` is total: a persisted event is a fact, and applying one cannot fail.
+- **`eventstore.Store`** — persistent storage for event streams (`StreamReader` + `StreamWriter`).
+- **`aggregatestore.Store[S]`** — the high-level interface applications use to create, load, and save aggregates.
+- **`aggregatestore.New(...)`** — constructs the event-sourced store, the primary implementation, which reconstructs aggregates by replaying their events.
+
+## Component Relationships
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    Application Layer                     │
+│             (commands, queries, domain logic)            │
+└─────────────┬────────────────────────────────────────────┘
+              │  New / Load / Save
+┌─────────────▼────────────────────────────────────────────┐
+│              Aggregate Store  (Store[S])                 │
+│                                                          │
+│   optional decorators, stackable in any order:           │
+│   ┌────────────┐  ┌────────────┐  ┌────────────┐         │
+│   │Snapshotting│  │   Cached   │  │  Hookable  │         │
+│   └────────────┘  └────────────┘  └────────────┘         │
+│                                                          │
+│   core implementation:                                   │
+│   ┌──────────────────────────────────────────────┐       │
+│   │  Event-sourced store (aggregatestore.New)    │       │
+│   │  • replays events to load aggregates         │       │
+│   │  • appends events to save them               │       │
+│   │  • owns domain event <-> bytes (codec)       │       │
+│   │  • owns the aggregate type name              │       │
+│   └──────────────────────────────────────────────┘       │
+└─────────────┬────────────────────────────────────────────┘
+              │  ReadStream / AppendStream
+┌─────────────▼────────────────────────────────────────────┐
+│                Event Store  (eventstore.Store)           │
+└─────────────┬────────────────────────────────────────────┘
+              │
+   ┌──────────┼──────────┬───────────┬───────────┐
+   │          │          │           │           │
+┌──▼─────┐ ┌──▼───┐ ┌────▼────┐ ┌────▼─────┐ ┌───▼────┐
+│Postgres│ │SQLite│ │ MongoDB │ │KurrentDB │ │ Memory │
+└────────┘ └──────┘ └─────────┘ └──────────┘ └────────┘
+```
+
+## Data Flow
+
+### Read Path: Loading an Aggregate
+
+1. The application calls `store.Load(ctx, id, nil)`.
+2. The store composes the aggregate's typed ID from its configured type name and the given UUID, creates the initial state with the factory, and hydrates it.
+3. Hydration calls `eventStore.ReadStream(...)` and, for each event, decodes the payload with the store's `DomainEventCodec` and applies it with `ApplyTo`, advancing the aggregate's version.
+
+With decorators in the stack: a snapshotting store first loads the latest snapshot and replays only the events after it; a cached store returns a cache hit without touching the event store at all.
+
+### Write Path: Saving an Aggregate
+
+1. The application queues events on the aggregate with `Append` (nothing is persisted or applied yet).
+2. `store.Save(ctx, aggregate, nil)` encodes each queued event with the `DomainEventCodec` and calls `eventStore.AppendStream(...)`, which enforces optimistic concurrency against the aggregate's loaded version.
+3. `AppendStream` returns the written events exactly as a subsequent read would — store-assigned IDs, versions, timestamps, and global positions — and the store applies them to the in-memory state.
+
+With decorators: a snapshotting store consults its policy after the save and captures a snapshot when due; a hookable store runs `BeforeSave`/`AfterSave` hooks; a cached store refreshes its entry.
+
+## Ownership Rules
+
+Estoria assigns each serialization and naming fact exactly one owner:
+
+- **Domain events → bytes** is owned by the aggregate store, through its `estoria.DomainEventCodec[S]` (JSON by default, overridable with `WithDomainEventCodec`). Event store backends persist those bytes verbatim, alongside the codec's declared content type — no backend re-encodes a payload it was handed.
+- **Entity state → bytes** (for snapshots and caches) is owned by the component doing the storing, through an `estoria.StateCodec[S]` (JSON by default).
+- **The aggregate type name** is owned by the aggregate store, supplied once at construction (`aggregatestore.New(eventStore, "account", NewAccount, ...)`). It becomes the type component of every aggregate ID the store composes, which is how streams are addressed in storage.
+
+## Store Decorators
+
+Decorators wrap any `aggregatestore.Store[S]` and can be stacked:
+
+- **[Snapshotting](../components/aggregate-store/snapshotting)** — loads state from snapshots instead of full replay; captures snapshots per a `SnapshotPolicy`.
+- **[Cached](../components/aggregate-store/cached)** — serves loads from an `AggregateCache[S]` backend, falling back to the inner store on a miss.
+- **[Hookable](../components/aggregate-store/hookable)** — runs lifecycle hooks (`BeforeLoad`, `AfterSave`, …) around the inner store's operations.
+
+```go
+store, _ := aggregatestore.New(eventStore, "account", NewAccount,
+    aggregatestore.WithEventTypes(AccountOpened{}, FundsDeposited{}))
+
+cached, _ := aggregatestore.NewCachedStore(store, cache)
+snapshotting, _ := aggregatestore.NewSnapshottingStore(cached, snapshotStore,
+    snapshotstore.EventCountSnapshotPolicy{N: 100})
+hookable, _ := aggregatestore.NewHookableStore(snapshotting)
+```
+
+## Extension Points
+
+Vendor-specific implementations live in [estoria-contrib](https://github.com/go-estoria/estoria-contrib); the [Component Library](/component-library) catalogs them.
+
+- **Event stores** implement `eventstore.Store`: PostgreSQL, SQLite, MongoDB, KurrentDB. The core library ships an in-memory store for testing. Optional capabilities — [global reads and stream deletion](../components/event-store#optional-capabilities) — are discovered by type assertion.
+- **Snapshot stores** implement `snapshotstore.SnapshotStore`. Both current implementations are in core: `snapshotstore/memory` and `snapshotstore/eventstream` (snapshots stored as events).
+- **Aggregate caches** implement `aggregatestore.AggregateCache[S]`: Redis, Valkey, Freecache, BigCache.
+- **Transactional outboxes** ride the PostgreSQL and MongoDB event stores' transaction hooks for [reliable delivery](../cqrs#the-transactional-outbox) to external consumers.
+- **Telemetry wrappers** ([OpenTelemetry, Datadog](../telemetry)) instrument event, aggregate, and snapshot stores without changing their behavior.
+
+Acceptance suites in `eventstore/storetest` and `snapshotstore/storetest` verify implementations against the behaviors Estoria's components rely on; every contrib backend runs them in CI.
+
+## Key Interfaces
+
+| Interface | Purpose | Key methods |
+|-----------|---------|-------------|
+| `estoria.DomainEvent[S]` | State-changing event | `EventType()`, `New()`, `ApplyTo(S) S` |
+| `estoria.DomainEventCodec[S]` | Domain event serialization | `MarshalDomainEvent`, `UnmarshalDomainEvent`, `ContentType` |
+| `estoria.StateCodec[S]` | Entity state serialization | `MarshalState`, `UnmarshalState`, `ContentType` |
+| `eventstore.Store` | Event persistence | `ReadStream`, `AppendStream` |
+| `eventstore.StreamIterator` | Event stream traversal | `Next`, `Close` |
+| `aggregatestore.Store[S]` | Aggregate operations | `New`, `Load`, `Hydrate`, `Save` |
+| `aggregatestore.AggregateCache[S]` | Aggregate caching | `GetAggregate`, `PutAggregate` |
+| `snapshotstore.SnapshotStore` | Snapshot persistence | `ReadSnapshot`, `WriteSnapshot` |
+
+## Further Reading
+
+- [Getting Started](../getting-started) — build a first Estoria application
+- [Components](../components) — detailed documentation for each component
+- [Integrations](../integrations) — setup guides for the contrib backends
+- [CQRS](../cqrs) — read models, projections, and the transactional outbox

--- a/content/docs/integrations.md
+++ b/content/docs/integrations.md
@@ -1,0 +1,177 @@
+---
+title: Integrations
+type: docs
+prev: docs/architecture/
+next: docs/troubleshooting/
+weight: 850
+---
+
+Vendor-specific backends live in the [estoria-contrib](https://github.com/go-estoria/estoria-contrib) module. This page covers first-time setup for each; the [Component Library](/component-library) catalogs them, and each backend's README documents its storage format and options in depth.
+
+## Event Stores
+
+### PostgreSQL
+
+Events are stored in a single table, with a companion streams table tracking per-stream offsets. The store takes a [pgx](https://github.com/jackc/pgx) connection pool.
+
+```go
+import (
+    pgeventstore "github.com/go-estoria/estoria-contrib/postgres/eventstore"
+    pgstrategy "github.com/go-estoria/estoria-contrib/postgres/eventstore/strategy"
+    "github.com/jackc/pgx/v5/pgxpool"
+)
+
+pool, err := pgxpool.New(ctx, "postgres://user:pass@localhost:5432/mydb")
+if err != nil { ... }
+
+// The strategy owns the schema; apply it once at deployment time.
+strategy, _ := pgstrategy.NewDefaultStrategy()
+if _, err := pool.Exec(ctx, strategy.Schema()); err != nil { ... }
+
+eventStore, err := pgeventstore.New(pool)
+```
+
+Notable options: `WithStrategy` (custom table names via the strategy's own options), `WithAppendTransactionHooks` (the [outbox](#transactional-outboxes) integration point), `WithTxOptions`, and `WithMaxEventDataBytes`.
+
+### SQLite
+
+The same single-table layout as PostgreSQL, over `database/sql` with the pure-Go [modernc.org/sqlite](https://gitlab.com/cznic/sqlite) driver — no CGO required.
+
+```go
+import (
+    "database/sql"
+    sqliteeventstore "github.com/go-estoria/estoria-contrib/sqlite/eventstore"
+    sqlitestrategy "github.com/go-estoria/estoria-contrib/sqlite/eventstore/strategy"
+    _ "modernc.org/sqlite"
+)
+
+db, err := sql.Open("sqlite", "file:events.db")
+if err != nil { ... }
+
+strategy, _ := sqlitestrategy.NewDefaultStrategy()
+if _, err := db.ExecContext(ctx, strategy.Schema()); err != nil { ... }
+
+eventStore, err := sqliteeventstore.New(db)
+```
+
+### MongoDB
+
+Events are stored in a single collection, or partitioned across collections by a configurable selector. Both strategies keep offset counters in a streams collection (`_streams` by default). **Multi-document transactions require a replica set** — a single-node replica set is sufficient.
+
+```go
+import (
+    mongoeventstore "github.com/go-estoria/estoria-contrib/mongodb/eventstore"
+    mongostrategy "github.com/go-estoria/estoria-contrib/mongodb/eventstore/strategy"
+    "go.mongodb.org/mongo-driver/v2/mongo"
+    "go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+client, err := mongo.Connect(options.Client().ApplyURI("mongodb://localhost:27017/?replicaSet=rs0"))
+if err != nil { ... }
+
+db := client.Database("myapp")
+
+// Single collection (the default shape):
+strategy, _ := mongostrategy.NewSingleCollectionStrategy(client,
+    db.Collection("events"),
+    db.Collection(mongostrategy.DefaultStreamsCollectionName),
+)
+
+// Or partitioned, one collection per stream type (or per stream ID, or custom):
+strategy, _ := mongostrategy.NewMultiCollectionStrategy(client, db,
+    mongostrategy.CollectionPerStreamType(),
+    mongostrategy.WithAutoEnsureIndexes(),
+)
+
+eventStore, err := mongoeventstore.New(client, mongoeventstore.WithStrategy(strategy))
+
+// Create the unique event indexes once at deployment time (the analog of Schema()).
+// With a selector that creates collections on the fly, use WithAutoEnsureIndexes instead.
+if err := eventStore.EnsureIndexes(ctx); err != nil { ... }
+```
+
+Collection names beginning with an underscore are reserved for infrastructure (stream counters, outboxes) and are excluded from global reads. If you are upgrading a database written before the counter-based storage format, see the [backfill instructions](https://github.com/go-estoria/estoria-contrib/tree/main/mongodb/eventstore#upgrading-from-derived-offsets) — with the unique indexes in place, an un-backfilled database fails loudly instead of silently rewriting history.
+
+### KurrentDB
+
+Estoria streams map 1:1 to [KurrentDB](https://www.kurrent.io/) streams, and global reads ride the server's `$all` stream.
+
+```go
+import (
+    kurrenteventstore "github.com/go-estoria/estoria-contrib/kurrentdb/eventstore"
+    "github.com/kurrent-io/KurrentDB-Client-Go/kurrentdb"
+)
+
+settings, err := kurrentdb.ParseConnectionString("kurrentdb://localhost:2113?tls=false")
+if err != nil { ... }
+
+client, err := kurrentdb.NewClient(settings)
+if err != nil { ... }
+
+eventStore, err := kurrenteventstore.New(client)
+```
+
+`WithStreamPrefix` namespaces one store's streams on a shared cluster (KurrentDB has no databases); `WithReadAllWindowSize` tunes global-read batching. This store deliberately does not implement stream deletion — KurrentDB's native delete semantics cannot honestly satisfy the interface's contract ([rationale](https://github.com/go-estoria/estoria-contrib/tree/main/kurrentdb/eventstore#unsupported-streamdeleter)).
+
+## Transactional Outboxes
+
+The PostgreSQL and MongoDB stores each ship a companion [outbox](../cqrs#the-transactional-outbox) package. Both register as transaction hooks — outbox items commit or roll back atomically with the events — and both run a polling consumer with at-least-once delivery to your handler.
+
+```go
+import pgoutbox "github.com/go-estoria/estoria-contrib/postgres/outbox"
+
+ob, _ := pgoutbox.New(pool, func(ctx context.Context, item *pgoutbox.Item) error {
+    return publish(ctx, item) // must be idempotent
+})
+
+eventStore, _ := pgeventstore.New(pool, pgeventstore.WithAppendTransactionHooks(ob))
+
+go ob.Run(ctx)
+```
+
+```go
+import mongooutbox "github.com/go-estoria/estoria-contrib/mongodb/outbox"
+
+ob, _ := mongooutbox.New(db.Collection("_outbox"), db.Collection("_outbox_streams"), handler)
+
+eventStore, _ := mongoeventstore.New(client,
+    mongoeventstore.WithStrategy(strategy),
+    mongoeventstore.WithTransactionHook(ob),
+)
+
+_ = ob.EnsureIndexes(ctx)
+go ob.Run(ctx)
+```
+
+The MongoDB outbox additionally guarantees strict per-stream delivery order via per-stream leases; see [its README](https://github.com/go-estoria/estoria-contrib/tree/main/mongodb/outbox) for the delivery contract.
+
+## Aggregate Caches
+
+Four cache backends implement `aggregatestore.AggregateCache[S]`: [Redis](https://github.com/go-estoria/estoria-contrib/tree/main/redis/aggregatecache) and [Valkey](https://github.com/go-estoria/estoria-contrib/tree/main/valkey/aggregatecache) (distributed), [Freecache](https://github.com/go-estoria/estoria-contrib/tree/main/freecache/aggregatecache) and [BigCache](https://github.com/go-estoria/estoria-contrib/tree/main/bigcache/aggregatecache) (in-process). All follow the same pattern:
+
+```go
+import (
+    rediscache "github.com/go-estoria/estoria-contrib/redis/aggregatecache"
+    "github.com/redis/go-redis/v9"
+)
+
+client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+
+cache := rediscache.New[Account](client,
+    rediscache.WithTTL[Account](5*time.Minute),
+)
+
+cachedStore, _ := aggregatestore.NewCachedStore(store, cache)
+```
+
+Each cache serializes entity state with a `StateCodec` (JSON by default, overridable with `WithStateCodec`). Choose in-process caches for single-instance applications and distributed caches when multiple instances must share hydration work.
+
+## Observability
+
+The [OpenTelemetry and Datadog wrappers](../telemetry) instrument event stores, aggregate stores, and snapshot stores with tracing and metrics. See the [Telemetry](../telemetry) page for setup.
+
+## Next Steps
+
+- [Getting Started](../getting-started) for the core usage patterns these backends plug into
+- [estoria-examples](https://github.com/go-estoria/estoria-examples) for complete runnable applications against each backend
+- [Troubleshooting](../troubleshooting) for common setup and runtime issues

--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -1,0 +1,136 @@
+---
+title: Troubleshooting
+type: docs
+prev: docs/integrations/
+weight: 860
+---
+
+Common issues encountered when using Estoria, and how to resolve them.
+
+## Stream Not Found
+
+`eventstore.ErrStreamNotFound` means the stream itself does not exist — the contract distinguishes this from a stream that exists but has no events matching the read options, which yields an empty iterator instead.
+
+**A read before any write is the normal first-load case.** A new aggregate has no stream yet; treat not-found as "create":
+
+```go
+account, err := store.Load(ctx, accountID, nil)
+if err != nil {
+    var loadErr aggregatestore.LoadError
+    if errors.As(err, &loadErr) && errors.Is(err, eventstore.ErrStreamNotFound) {
+        account = store.New(accountID) // first interaction with this aggregate
+    } else {
+        return err
+    }
+}
+```
+
+Other causes worth checking:
+
+- **Mismatched aggregate type name.** The stream's type component comes from the name given to `aggregatestore.New(eventStore, "account", ...)`. Two stores with different type names address entirely different streams, even for the same UUID.
+- **Wrong backend or database.** Confirm the connection string and database/collection names point where the events were actually written.
+- **Malformed stream IDs** when reading the event store directly: aggregate stream IDs render as `account_9f4c...` (type name, underscore, UUID). Parse strings with `typeid.Parse`; construct fresh IDs with `typeid.NewV4("account")` or `typeid.New("account", uuid)`.
+
+## Version Mismatch
+
+```
+stream version mismatch: expected version 3, got version 5
+```
+
+`eventstore.StreamVersionMismatchError` is optimistic concurrency doing its job: the aggregate was saved by someone else after you loaded it. Retry with a fresh load:
+
+```go
+for range maxRetries {
+    account, err := store.Load(ctx, accountID, nil)
+    if err != nil {
+        return err
+    }
+
+    account.Append(FundsDeposited{Amount: amount}) // re-derive from fresh state
+
+    err = store.Save(ctx, account, nil)
+    if err == nil {
+        return nil
+    }
+    if !errors.Is(err, eventstore.StreamVersionMismatchError{}) {
+        return err
+    }
+    // conflict: loop reloads and re-applies
+}
+```
+
+Two things to keep in mind:
+
+- **Re-derive, don't replay, your intent.** Business logic must run against the freshly loaded state — the command may no longer be valid after the conflicting save.
+- **A save can fail *after* its events were appended** (for example while applying them in memory). That error carries the `aggregatestore.ErrEventsAppended` sentinel; recover by discarding the aggregate and reloading, not by retrying the save.
+
+**If retries never succeed on the MongoDB backend**, and the store was migrated from a pre-counter storage format, the offset counters may be missing: the store then reissues offsets that already exist, and the unique event indexes reject every append as a version mismatch. Run the [backfill](https://github.com/go-estoria/estoria-contrib/tree/main/mongodb/eventstore#upgrading-from-derived-offsets) once.
+
+## Codec Errors
+
+Domain events and snapshot state are serialized by codecs — `estoria.DomainEventCodec[S]` for events, `estoria.StateCodec[S]` for state — JSON by default. Failures surface wrapped in the operation that hit them (`aggregatestore.SaveError`, `HydrateError`, or `eventstore.EventMarshalingError` / `EventUnmarshalingError`).
+
+- **Unexported fields silently don't round-trip** with the JSON codecs. Keep event and state fields exported, and unit-test a marshal/unmarshal round trip per event type.
+- **Unregistered event types fail hydration.** Every event type that can appear in a stream must be registered with `aggregatestore.WithEventTypes(...)`; the store uses each event's `New()` to instantiate the right concrete type before decoding.
+- **Custom codec pointer semantics:** `UnmarshalState(data []byte, dest *S)` receives `dest` already a pointer. Pass it straight through — `json.Unmarshal(data, dest)`, never `&dest`; the double pointer decodes into a discarded temporary.
+
+```go
+// WRONG: &dest is **S; the decoded value is lost
+func (c Codec[S]) UnmarshalState(data []byte, dest *S) error {
+    return json.Unmarshal(data, &dest)
+}
+
+// CORRECT
+func (c Codec[S]) UnmarshalState(data []byte, dest *S) error {
+    return json.Unmarshal(data, dest)
+}
+```
+
+## Snapshot Issues
+
+**`snapshotstore.ErrSnapshotNotFound` on a first load is normal** — no snapshot exists until the snapshot policy has triggered once. The snapshotting store handles it internally by falling back to full event replay; don't treat it as an error in application code.
+
+- **Snapshots never being taken?** Check the policy: `snapshotstore.EventCountSnapshotPolicy{N: 100}` captures every 100 events, and the policy is consulted only after a successful save.
+- **Snapshots being skipped on load?** A snapshot declaring a content type the store's `StateCodec` does not produce is skipped in favor of event replay — expected after changing codecs; the next save writes a fresh snapshot.
+- **The eventstream snapshot store** persists snapshots in a companion stream named by suffixing the aggregate's type: aggregate `account_<uuid>` snapshots to stream `accountsnapshot_<uuid>`. Old snapshots can be pruned automatically with `WithMaxSnapshots`.
+
+## Backend-Specific Issues
+
+### PostgreSQL and SQLite
+
+- **`relation "event" does not exist`** (or the SQLite equivalent): the schema was never applied. The strategy owns it — run `strategy.Schema()` against the database once at deployment time.
+- The Postgres store takes a **pgx pool** (`pgxpool.New`), not a `database/sql` handle; SQLite takes `database/sql` with the `modernc.org/sqlite` driver (`sql.Open("sqlite", ...)`).
+
+### MongoDB
+
+- **`Transaction numbers are only allowed on a replica set member`**: Estoria's MongoDB store requires multi-document transactions, which MongoDB only supports on a replica set. A single-node replica set is sufficient (`mongod --replSet rs0` + `rs.initiate()`; testcontainers and most compose setups can do this for you).
+- **Missing unique indexes** leave appends without their concurrency backstop. Call `EnsureIndexes` at deployment time, or use the strategy's `WithAutoEnsureIndexes` when a collection selector creates collections on the fly.
+- **Underscore-prefixed collections are reserved.** The multi-collection strategy excludes them from global reads, and a collection selector that names one is rejected on writes.
+
+### KurrentDB
+
+- **Connection scheme**: use `kurrentdb://host:2113`, with `?tls=false` only for local development — KurrentDB requires TLS by default.
+- **Stream deletion is deliberately unsupported** ([rationale](https://github.com/go-estoria/estoria-contrib/tree/main/kurrentdb/eventstore#unsupported-streamdeleter)); a `StreamDeleter` type assertion on this store correctly reports false.
+- **Sharing a cluster** between stores or environments? KurrentDB has no databases; use `WithStreamPrefix` to namespace each store's streams.
+
+### Aggregate Caches
+
+- **Stale reads** are the TTL trade-off; tune with the cache's `WithTTL` option.
+- **Codec mismatches** between writer and reader instances (for example after changing `WithStateCodec`) surface as cache misses or unmarshal failures — flush the cache when changing codecs.
+
+### Outboxes
+
+- **Items not being delivered**: confirm the outbox is registered with the event store (`WithAppendTransactionHooks` for Postgres, `WithTransactionHook` for MongoDB) and that a consumer (`Run` or `ProcessNext`) is actually running.
+- **A MongoDB outbox stream stops delivering**: after `WithMaxRetries` consecutive failures the item is marked failed and its stream halts for operator inspection — later events in that stream wait until the failed item is resolved. Handlers must be idempotent; delivery is at-least-once.
+
+## General Debugging
+
+- **Enable logging:** `estoria.SetLogger(...)` routes Estoria's internal logging to your logger.
+- **Instrument the stores:** the [OpenTelemetry and Datadog wrappers](../telemetry) trace every read, append, and iterator advance.
+- **Classify errors, don't string-match:** everything Estoria returns supports `errors.Is`/`errors.As` — sentinels like `eventstore.ErrStreamNotFound` and typed wrappers like `aggregatestore.SaveError` compose.
+
+## Further Reading
+
+- [Architecture Overview](../architecture) — who owns which responsibility
+- [Integrations](../integrations) — backend setup guides
+- [Examples](../examples) — complete runnable applications to compare against

--- a/content/docs/typeids.md
+++ b/content/docs/typeids.md
@@ -2,6 +2,7 @@
 title: TypeIDs
 type: docs
 prev: docs/cqrs/
+next: docs/architecture/
 weight: 830
 ---
 


### PR DESCRIPTION
## Summary

Adds three pages:

- **Architecture Overview** (`/docs/architecture`) — component map, read/write data flows, decorator stacking, and extension points, rebuilt on the current API: `DomainEvent[S]` with total `ApplyTo`, codec-based serialization, and an explicit *Ownership Rules* section (the aggregate store owns domain-event bytes via `DomainEventCodec`; state bytes belong to the component storing them via `StateCodec`; the store owns the aggregate type name). The backend set is current: SQLite and the outboxes are in, S3 is gone.
- **Integrations** (`/docs/integrations`) — per-backend setup guides, corrected throughout: pgx pool instead of `lib/pq`, the three-argument MongoDB strategy constructors with `EnsureIndexes`/`WithAutoEnsureIndexes` and the offset-backfill warning (replacing a "known limitation" about out-of-transaction offsets that no longer exists), `kurrentdb://` scheme with `WithStreamPrefix` (replacing an obsolete claim about a hardcoded read limit), a new SQLite section, wiring examples for both transactional outboxes, and the four aggregate caches.
- **Troubleshooting** (`/docs/troubleshooting`) — the error catalog on the current error vocabulary: sentinel/wrapper types with `errors.Is`/`As`, the `ErrEventsAppended` recovery path, optimistic-concurrency retry guidance, the MongoDB replica-set requirement and the "retries never succeed → run the backfill" diagnosis, outbox halted-stream behavior, and the `UnmarshalState` double-pointer gotcha.
